### PR TITLE
Fix example module spec

### DIFF
--- a/module/v1/schema.json
+++ b/module/v1/schema.json
@@ -166,20 +166,17 @@
       ]
     },
     "structuredParameter": {
-      "type": "array",
-      "items": {
-        "oneOf": [
-          {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/paramSpec"
+        },
+        {
+          "type": "array",
+          "items": {
             "$ref": "#/$defs/paramSpec"
-          },
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/$defs/paramSpec"
-            }
           }
-        ]
-      }
+        }
+      ]
     },
     "paramSpec": {
       "type": "object",
@@ -192,7 +189,7 @@
         },
         "type": {
           "type": "string",
-          "description": "Parameter input/output",
+          "description": "Parameter type",
           "enum": [
             "boolean",
             "float",
@@ -233,7 +230,7 @@
           "uniqueItems": true
         }
       },
-      "required": ["name", "type", "description"]
+      "required": ["type", "description"]
     }
   }
 }

--- a/module/v1/tests/invalid_input_output.yml
+++ b/module/v1/tests/invalid_input_output.yml
@@ -1,0 +1,39 @@
+name: fastqc
+description: Run FastQC on sequenced reads
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - reads:
+        type: file
+        description: |
+          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+          respectively.
+output:
+  - html:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.html":
+          type: file
+          description: FastQC report
+          pattern: "*_{fastqc.html}"
+  - zip:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.zip":
+          type: file
+          description: FastQC report archive
+          pattern: "*_{fastqc.zip}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"

--- a/module/v1/tests/valid_spec.yml
+++ b/module/v1/tests/valid_spec.yml
@@ -19,42 +19,34 @@ tools:
       licence: ["GPL-2.0-only"]
       identifier: biotools:fastqc
 input:
-  - - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. [ id:'test', single_end:false ]
-    - reads:
-        type: file
-        description: |
-          List of input FastQ files of size 1 and 2 for single-end and paired-end data,
-          respectively.
+  - - name: meta
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+    - name: reads
+      type: file
+      description: |
+        List of input FastQ files of size 1 and 2 for single-end and paired-end data,
+        respectively.
 output:
-  - html:
-      - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-      - "*.html":
-          type: file
-          description: FastQC report
-          pattern: "*_{fastqc.html}"
-  - zip:
-      - meta:
-          type: map
-          description: |
-            Groovy Map containing sample information
-            e.g. [ id:'test', single_end:false ]
-      - "*.zip":
-          type: file
-          description: FastQC report archive
-          pattern: "*_{fastqc.zip}"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+  - - type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+    - type: file
+      description: FastQC report
+      pattern: "*_{fastqc.html}"
+  - - type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+    - type: file
+      description: FastQC report archive
+      pattern: "*_{fastqc.zip}"
+  - type: file
+    description: File containing software versions
+    pattern: "versions.yml"
 authors:
   - "@drpatelh"
   - "@grst"


### PR DESCRIPTION
- Update `valid_spec.yml` to adhere to module schema
- Remove incorrect nested array in module input/output schema
- Add invalid example using legacy input/output syntax